### PR TITLE
feat: add cleanUp option to reduce disk use; document scripts in README

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,7 +6,7 @@ on:
     - cron: '04 23 * * 1'
 concurrency:
   group: cicd-${{ github.ref }}
-  cancel-in-progress: true  
+  cancel-in-progress: true
 jobs:
   Install-Ubuntu-NonRoot:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
       - name: Run the installation script
         run: |
           cd $INSTALLER_PATH
-          ./galacticusInstall.sh --galacticusPrefix=$INSTALLER_PATH/galacticus --toolPrefix=$INSTALLER_PATH/install --asRoot=no --cores=4 --installLevel=minimal --setBash=yes --setCShell=no --ignoreFailures=no --packageManager=no --catLogOnError=yes
+          ./galacticusInstall.sh --galacticusPrefix=$INSTALLER_PATH/galacticus --toolPrefix=$INSTALLER_PATH/install --asRoot=no --cores=4 --installLevel=minimal --setBash=yes --setCShell=no --ignoreFailures=no --packageManager=no --catLogOnError=yes --cleanUp=yes
   Install-Rocky-Root:
     runs-on: ubuntu-latest
     container:
@@ -40,7 +40,7 @@ jobs:
       - name: Run the installation script
         run: |
           cd $INSTALLER_PATH
-          ./galacticusInstall.sh --galacticusPrefix=$INSTALLER_PATH/galacticus --toolPrefix=$INSTALLER_PATH/install --asRoot=yes --cores=4 --installLevel=minimal --setBash=yes --setCShell=no --ignoreFailures=no --packageManager=yes --catLogOnError=yes
+          ./galacticusInstall.sh --galacticusPrefix=$INSTALLER_PATH/galacticus --toolPrefix=$INSTALLER_PATH/install --asRoot=yes --cores=4 --installLevel=minimal --setBash=yes --setCShell=no --ignoreFailures=no --packageManager=yes --catLogOnError=yes --cleanUp=yes
   Install-MacOS:
     strategy:
       # Ensure all jobs are run, even if some fail.

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+# yamllint configuration for this repository.
+#
+# Relaxes a few of yamllint's stricter defaults that are impractical for GitHub
+# Actions workflows: the installer is invoked with a long single-line command, so
+# line-length is disabled, and the `on:` workflow trigger key is a legitimate
+# (not "truthy") use.
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable
+  truthy:
+    check-keys: false
+  brackets:
+    max-spaces-inside: 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,91 @@
 # Galacticus Installation Scripts
-Installation script for the Galacticus galaxy formation model
 
-This repo contains scripts which attempt to install the [Galacticus](https://bitbucket.org/galacticusdev/galacticus/wiki/Home) semi-analytic model. They are intended for use on Linux and MacOS systems. See the [wiki](https://github.com/galacticusorg/installationscripts/wiki) for full details.
+Installation scripts for the [Galacticus](https://github.com/galacticusorg/galacticus) semi-analytic galaxy formation model.
+
+This repo contains scripts which attempt to install Galacticus, together with all of the tools and libraries that it depends on. They are intended for use on Linux and macOS systems. Where a dependency is not already available (or is too old), the scripts will install it — either via the system package manager or by compiling it from source. See the [wiki](https://github.com/galacticusorg/installationscripts/wiki) for full details.
+
+There are two scripts:
+
+| Script                      | Platform | Notes                                                              |
+| --------------------------- | -------- | ------------------------------------------------------------------ |
+| `galacticusInstall.sh`      | Linux    | Highly configurable; can install as root or as a regular user.     |
+| `galacticusInstallMacOS.sh` | macOS    | Uses [MacPorts](https://www.macports.org/) plus a prebuilt GCC 16. |
+
+## Linux: `galacticusInstall.sh`
+
+### Quick start
+
+Run the script with no arguments and it will prompt you interactively for everything it needs:
+
+```bash
+./galacticusInstall.sh
+```
+
+Alternatively, supply any (or all) of the options below to run non-interactively — any option you omit will still be prompted for. This is the recommended way to drive the script in scripted/CI environments.
+
+```bash
+./galacticusInstall.sh \
+    --toolPrefix=$HOME/Galacticus/Tools \
+    --galacticusPrefix=$HOME/Galacticus/galacticus \
+    --asRoot=no \
+    --installLevel=minimal \
+    --cores=4 \
+    --packageManager=no \
+    --setBash=yes \
+    --setCShell=no
+```
+
+### Options
+
+Options use the form `--option=value` (note the `=`; a space will not work). All are optional — anything not specified on the command line is requested interactively.
+
+| Option                    | Values                     | Description                                                                                                                                  |
+| ------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--toolPrefix=PATH`       | path                       | Where to install supporting tools and libraries. Defaults to `/usr/local/galacticus` (root) or `$HOME/Galacticus/Tools` (regular user).     |
+| `--galacticusPrefix=PATH` | path                       | Where to install Galacticus itself. Defaults to `$HOME/Galacticus/galacticus`.                                                              |
+| `--asRoot=`               | `yes` \| `no`              | Install required libraries as root (needed to write to system locations or use the package manager).                                        |
+| `--rootPwd=`              | password                   | The root/sudo password, used when `--asRoot=yes`. (Avoid passing this on shared systems — it may be visible in your shell history.)         |
+| `--suMethod=`             | `su` \| `sudo`             | Which command to use to gain root for root installs.                                                                                        |
+| `--packageManager=`       | `yes` \| `no`              | When installing as root, use the system package manager (`yum`/`apt`) where a suitable version is available, instead of building from source. |
+| `--installLevel=`         | `binary` \| `minimal` \| `full` | How much to install (see below).                                                                                                       |
+| `--cores=`                | integer                    | Number of CPU cores to use when compiling.                                                                                                  |
+| `--setBash=`              | `yes` \| `no`              | Add a `galacticus` shell function to `~/.bashrc` that configures the environment (paths, flags) needed to build and run Galacticus.         |
+| `--setCShell=`            | `yes` \| `no`              | As `--setBash`, but adds a `galacticus` alias to `~/.cshrc`.                                                                                |
+| `--ignoreFailures=`       | `yes` \| `no`              | If a package cannot be installed from source, continue anyway (`yes`) rather than aborting (`no`). Continuing may lead to later errors.     |
+| `--catLogOnError=`        | `yes` \| `no`              | On error, print the full install log to standard output. Useful in CI where the log file is otherwise inaccessible. Default `no`.           |
+| `--cleanUp=`              | `yes` \| `no`              | After each successful install from source, remove the downloaded tarball (or cloned repo) and the unpacked source/build directories to reduce disk-space usage. Default `no` (keep them). |
+| `--force-PACKAGE`         | (flag)                     | Force (re)installation of a specific package even if a suitable version is already present, e.g. `--force-hdf5`, `--force-gsl`, `--force-gcc`. |
+
+### Install levels
+
+* **`binary`** — Download the prebuilt `Galacticus.exe` static binary plus the datasets needed to run it. No compilation of Galacticus itself.
+* **`minimal`** — Install just enough tools and libraries to compile and run Galacticus, then clone and build it from source.
+* **`full`** — As `minimal`, plus additional optional libraries (e.g. FFTW3, ANN, QHull).
+
+### What the script does
+
+1. Creates a working directory, `galacticusInstallWork`, beneath the current directory and performs all downloads and source builds there.
+2. Checks each required tool/library; if it is missing or out of the supported version range, installs it via the package manager (if enabled) or from source.
+3. Clones Galacticus and its datasets, creates a Python virtual environment, and installs Galacticus' Python build dependencies (for non-`binary` installs).
+4. Builds `Galacticus.exe` (for non-`binary` installs) and runs a short test case (`parameters/quickTest.xml`, ~1 minute) to verify the installation.
+
+A log of the entire run is written to `galacticusInstall.log` in the directory from which you launched the script. Once finished, the `galacticusInstallWork` directory can be safely deleted.
+
+If you opted in to `--setBash`/`--setCShell`, run `galacticus` in a new shell to configure the environment before using Galacticus.
+
+## macOS: `galacticusInstallMacOS.sh`
+
+This script takes no options — simply run it:
+
+```bash
+./galacticusInstallMacOS.sh
+```
+
+Notes:
+
+* You will need `sudo` privileges and will be prompted for your password (possibly several times) during the installation.
+* If prompted to make a choice during installation, accept the default (just press <kbd>Enter</kbd>).
+* If a pop-up appears saying *“Terminal” would like to administer your computer*, approve it.
+* It installs the Xcode command-line tools, [MacPorts](https://www.macports.org/), and a prebuilt GCC 16, then builds the remaining dependencies (HDF5, FoX, FFTW, ANN, …) from source before cloning and building Galacticus.
+
+This script should be considered a **beta release**. If you run into problems, please report them on the [Galacticus discussion forum](https://github.com/galacticusorg/galacticus/discussions).

--- a/galacticusInstall.sh
+++ b/galacticusInstall.sh
@@ -33,7 +33,7 @@ function logmessage()
 glcLogFile=`pwd`"/galacticusInstall.log"
 
 # Get arugments.
-TEMP=`getopt -o t --long toolPrefix::,asRoot::,rootPwd::,suMethod::,installLevel::,packageManager::,cores::,galacticusPrefix::,setCShell::,setBash::,ignoreFailures::,catLogOnError:: -- "$@"`
+TEMP=`getopt -o t --long toolPrefix::,asRoot::,rootPwd::,suMethod::,installLevel::,packageManager::,cores::,galacticusPrefix::,setCShell::,setBash::,ignoreFailures::,catLogOnError::,cleanUp:: -- "$@"`
 eval set -- "$TEMP"
 cmdToolPrefix=
 cmdAsRoot=
@@ -47,6 +47,7 @@ cmdSetCShell=
 cmdSetBash=
 cmdIgnoreFailures=
 cmdCatLogOnError=
+cmdCleanUp=
 while true; do
     case "$1" in
 	--asRoot ) cmdAsRoot="$2"; shift 2 ;;
@@ -59,6 +60,7 @@ while true; do
 	--setBash ) cmdSetBash="$2"; shift 2 ;;
 	--ignoreFailures ) cmdIgnoreFailures="$2"; shift 2 ;;
 	--catLogOnError ) cmdCatLogOnError="$2"; shift 2 ;;
+	--cleanUp ) cmdCleanUp="$2"; shift 2 ;;
 	--suMethod ) cmdSuMethod="$2"; shift 2 ;;
 	--toolPrefix ) cmdToolPrefix="$2"; shift 2 ;;
 	-- ) shift; break ;;
@@ -97,6 +99,12 @@ if [ ! -z ${cmdCatLogOnError} ]; then
 	exit 1
     fi
 fi
+if [ ! -z ${cmdCleanUp} ]; then
+    if [[ ${cmdCleanUp} != "no" && ${cmdCleanUp} != "yes" ]]; then
+	logmessage "cleanUp option should be 'yes' or 'no'"
+	exit 1
+    fi
+fi
 if [ ! -z ${cmdSuMethod} ]; then
     if [[ ${cmdSuMethod} != "su" && ${cmdSuMethod} != "sudo" ]]; then
 	logmessage "suMethod option should be 'su' or 'sudo'"
@@ -126,6 +134,12 @@ fi
 catLogOnError="no"
 if [ ! -z ${cmdCatLogOnError} ]; then
     catLogOnError=$cmdCatLogOnError
+fi
+# Whether to remove the downloaded tarball (or cloned repo) and the source/build directories after a successful
+# install from source. Defaults to "no" (keep them); set to "yes" (e.g. in CI) to reduce disk-space usage.
+cleanUp="no"
+if [ ! -z ${cmdCleanUp} ]; then
+    cleanUp=$cmdCleanUp
 fi
 
 # Open the log file.
@@ -1504,6 +1518,21 @@ EOF
 		    fi
 		fi
 		cd ..
+		# Optionally clean up the downloaded tarball (or cloned repo) and the source/build directories now
+		# that the install from source has succeeded. This helps keep disk-space usage low (e.g. in CI), which
+		# matters because these installs compile many large packages (GCC, HDF5, ...) from source.
+		if [ "$cleanUp" = yes ]; then
+		    echo "   Cleaning up source for ${package[$i]}"
+		    echo "   Cleaning up source for ${package[$i]}" >> $glcLogFile
+		    # baseName/dirName are set above when the source was fetched/unpacked. Guard against empty values so
+		    # we never run a destructive "rm -rf" with a missing path.
+		    if [ -n "$baseName" ]; then
+			logexec rm -rf \"$baseName\"
+		    fi
+		    if [ -n "$dirName" ]; then
+			logexec rm -rf \"$dirName\" \"$dirName-build\"
+		    fi
+		fi
 		# Re-export the PATH so that the newly installed executable gets picked up.
 		export PATH=$PATH
 		installDone=1


### PR DESCRIPTION
## Summary

Addresses the out-of-disk failure seen in the `Install-Rocky-Root` CI job, and fills out the previously near-empty README.

### Source cleanup (`--cleanUp`)
- New `--cleanUp=yes|no` option in `galacticusInstall.sh`. After each **successful** install from source, it removes the downloaded tarball (or cloned repo) and the unpacked source/build directories, keeping peak disk usage low. These installs compile many large packages (GCC 16, HDF5, …) from source, so the intermediate files add up.
- Defaults to `no` (keep the files), as requested.
- Removals are guarded against empty `baseName`/`dirName` so a missing variable can never become a destructive `rm -rf`, and they use the existing `logexec` helper so they are logged.
- The CI workflow (`cicd.yml`) sets `--cleanUp=yes` for the `Install-Rocky-Root` and `Install-Ubuntu-NonRoot` jobs (both build from source).
- The macOS script already cleaned up unconditionally, so it is unchanged.

### README
- Quick-start (interactive and non-interactive) usage.
- Full table of all command-line options, including the new `--cleanUp` and the `--force-PACKAGE` flag, documenting the `--option=value` syntax.
- Explanation of the `binary` / `minimal` / `full` install levels and of what each script does.
- macOS notes (sudo, prompts, MacPorts + prebuilt GCC 16, beta-release warning).
- Updated the stale Bitbucket link to the current GitHub locations.

### Tooling
- Added a `.yamllint` config (line-length disabled, etc.) so the pre-commit YAML check accepts the long single-line GitHub Actions commands, and trimmed a pre-existing trailing space in `cicd.yml`.

## Test plan
- `bash -n galacticusInstall.sh` passes.
- `yamllint` passes on `cicd.yml` and `.yamllint`.
- CI jobs exercise the new `--cleanUp=yes` path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)